### PR TITLE
minor fix v1.0.0.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 3,
     "name": "Helper Extension for Gridiron Dynasty",
-    "version": "1.0.0.1",
+    "version": "1.0.0.2",
     "description": "Add recruit hometown mapping links, recruit considering color, box score analysis links",
     "browser_specific_settings": {
       "gecko": {

--- a/scripts/main-page.js
+++ b/scripts/main-page.js
@@ -251,12 +251,12 @@ async function insertLinksPreviousGame(active_tid, season) { // Ensure this func
 
         const prior_opp_team_name = document
             .getElementById('ctl00_ctl00_ctl00_Main_Main_Main_LastGame_contentBox')
-            .getElementsByClassName('teamProfileLink')[1]
+            .querySelector('a.teamProfileLink')
             .textContent;
 
         const prior_opp_tid = document
             .getElementById('ctl00_ctl00_ctl00_Main_Main_Main_LastGame_contentBox')
-            .getElementsByClassName('teamProfileLink')[1]
+            .querySelector('a.teamProfileLink')
             .getAttribute('href')
             .match(/OpenTeamProfile\((\d{5})/)[1];
 


### PR DESCRIPTION
Fixes an issue where sometimes the order of 2 elements were not rendered the same on different browsers, and the queryselector logic would pick the wrong element to update. This minor code change resolves that by explicitly selecting the teamProfileLink class associated with the <a> tag.